### PR TITLE
Align branding with PMOVES-DoX naming

### DIFF
--- a/ADVANCED_FEATURES_PLAN.md
+++ b/ADVANCED_FEATURES_PLAN.md
@@ -754,7 +754,7 @@ class CitationHighlighter:
 from celery import Celery
 import asyncio
 
-celery_app = Celery('meeting_analyst', broker='redis://localhost:6379')
+celery_app = Celery('pmoves_dox', broker='redis://localhost:6379')
 
 @celery_app.task
 def process_document_async(file_path: str, report_week: str):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# AGENTS.md — Agent Working Agreement (PMOVES_DoX)
+# AGENTS.md — Agent Working Agreement (PMOVES-DoX)
 
-This file defines how agents should work within this repository. Its scope covers the entire `PMOVES_DoX/` directory tree.
+This file defines how agents should work within this repository. Its scope covers the entire `PMOVES-DoX/` directory tree.
 
 ## Mission
 Build and operate a documentation + troubleshooting workbench focused on LMS docs (PDF), XML logs, and API collections (OpenAPI/Postman). Core features:
@@ -9,7 +9,7 @@ Build and operate a documentation + troubleshooting workbench focused on LMS doc
 - Search and visualize with datavzrd dashboards; schema docs with schemavzrd
 
 ## Environment Expectations (Codex CLI)
-- Filesystem: full write access within this repo; ok to create/modify files under `PMOVES_DoX/`
+- Filesystem: full write access within this repo; ok to create/modify files under `PMOVES-DoX/`
 - Network: enabled (to build images, pull models, fetch dependencies)
 - Approvals: prefer `on-failure` or `never` for smooth iteration
 - GPU: available on machines running the GPU compose profile (NVIDIA Container Toolkit required)

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,7 +1,7 @@
 # Project Structure Overview
 
 ```
-PMOVES_DoX/
+PMOVES-DoX/
 ├── README.md                           # Main documentation
 ├── ADVANCED_FEATURES_PLAN.md          # Roadmap for advanced features
 ├── setup.ps1                          # Windows setup script

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PMOVES_DoX
+# PMOVES-DoX
 
 The ultimate document structured data extraction and analysis tool. Extract, analyze, transform, and visualize data from PDFs, XML logs, CSV/XLSX, and OpenAPI/Postman collections. Local‑first with Hugging Face + Ollama; ships as standalone, Docker, and MS Teams Copilot/MCP‑friendly.
 
@@ -7,7 +7,7 @@ The ultimate document structured data extraction and analysis tool. Extract, ana
 Option A - Docker (CPU, default)
 
 ```bash
-cd PMOVES_DoX
+cd PMOVES-DoX
 cp .env.example .env  # first time only
 docker compose -f docker-compose.cpu.yml up --build -d
 ```
@@ -15,7 +15,7 @@ docker compose -f docker-compose.cpu.yml up --build -d
 Option B — GPU + Tools (internal Ollama, no host port conflicts)
 
 ```bash
-cd PMOVES_DoX
+cd PMOVES-DoX
 cp .env.example .env  # first time only
 # Start full stack with GPU backend + internal Ollama + tools (datavzrd/schemavzrd)
 docker compose --compatibility --profile ollama --profile tools up --build -d
@@ -30,7 +30,7 @@ Option C — Local dev
 
 1) Backend
 ```bash
-cd PMOVES_DoX/backend
+cd PMOVES-DoX/backend
 python -m venv venv && . venv/bin/activate  # Windows: .\venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 uvicorn app.main:app --host 0.0.0.0 --port 8000
@@ -38,7 +38,7 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
 
 2) Frontend
 ```bash
-cd PMOVES_DoX/frontend
+cd PMOVES-DoX/frontend
 npm i
 npm run dev
 ```
@@ -143,7 +143,7 @@ OpenAPI/XML enrichments
 
 ```powershell
 # Navigate to backend directory
-cd PMOVES_DoX/backend
+cd PMOVES-DoX/backend
 
 # Copy env template (optional)
 copy .env.example .env
@@ -172,7 +172,7 @@ Backend will run on `http://localhost:8000`
 
 ```powershell
 # Navigate to frontend directory
-cd PMOVES_DoX/frontend
+cd PMOVES-DoX/frontend
 
 # Copy env template (optional)
 copy .env.local.example .env.local
@@ -191,7 +191,7 @@ Frontend will run on `http://localhost:3000`
 Prereqs: Docker Desktop installed and running.
 
 ```powershell
-cd PMOVES_DoX
+cd PMOVES-DoX
 # Optional (recommended on Docker Desktop):
 docker compose --compatibility up --build
 ```
@@ -202,7 +202,7 @@ docker compose --compatibility up --build
  - schemavzrd schema docs (if DB_URL is set): http://localhost:5174
 
 Data folders `backend/uploads` and `backend/artifacts` are volume-mounted.
-There is also a watch folder: `PMOVES_DoX/watch` mounted to `/app/watch` in the backend.
+There is also a watch folder: `PMOVES-DoX/watch` mounted to `/app/watch` in the backend.
 
 PDF OCR support in container: the backend image installs `poppler-utils`, `tesseract-ocr`, and `tesseract-ocr-eng` to support Docling’s PDF parsing and OCR.
 
@@ -237,7 +237,7 @@ $env:DOCLING_VLM_REPO = 'ibm-granite/granite-docling-258M'
 2) Start (GPU is default in docker-compose.yml):
 
 ```
-cd PMOVES_DoX
+cd PMOVES-DoX
 docker compose --compatibility --profile ollama --profile tools up --build -d
 ```
 
@@ -253,7 +253,7 @@ Jetson Nano (JetPack 4.x, L4T r32.7.1)
 
 ```bash
 # On the Jetson device (ARM64)
-cd PMOVES_DoX
+cd PMOVES-DoX
 cp .env.example .env
 
 # Start backend + frontend (CPU/GPU via L4T runtime)
@@ -275,7 +275,7 @@ Use the Orin-specific compose + Dockerfile that default to an L4T ML base for r3
 
 ```bash
 # On the Orin Nano (ARM64)
-cd PMOVES_DoX
+cd PMOVES-DoX
 cp .env.example .env
 
 # Start backend + frontend with Orin/L4T base (defaults to r36.3.0)
@@ -303,12 +303,12 @@ Notes
 4. **View Citations**: See exactly where each fact came from with page numbers and coordinates
 
 ### Sample files
-- CSV: `PMOVES_DoX/samples/sample.csv`
-- PDF: `PMOVES_DoX/samples/sample.pdf` (downloaded by `setup.ps1`; or use any PDF you have)
+- CSV: `PMOVES-DoX/samples/sample.csv`
+- PDF: `PMOVES-DoX/samples/sample.pdf` (downloaded by `setup.ps1`; or use any PDF you have)
 
 ### Watch Folder
 
-Drop `.pdf`, `.csv`, `.xlsx`, or `.xls` files into `PMOVES_DoX/watch` and the backend will auto-ingest them. Behavior is controlled by env vars (see `backend/.env.example`):
+Drop `.pdf`, `.csv`, `.xlsx`, or `.xls` files into `PMOVES-DoX/watch` and the backend will auto-ingest them. Behavior is controlled by env vars (see `backend/.env.example`):
 
 - `WATCH_ENABLED` (default `true`)
 - `WATCH_DIR` (default `/app/watch` in the container)
@@ -365,7 +365,7 @@ Notes:
 ## Project Structure
 
 ```
-PMOVES_DoX/
+PMOVES-DoX/
 ├── backend/
 │   ├── app/
 │   │   ├── main.py              # FastAPI application
@@ -397,7 +397,7 @@ See `ADVANCED_FEATURES_PLAN.md` for roadmap of advanced PDF processing features.
 One-command smoke via npm (uses Python + Docker Compose under the hood):
 
 ```bash
-cd PMOVES_DoX
+cd PMOVES-DoX
 npm run smoke         # CPU compose (default)
 npm run smoke:gpu     # GPU compose (internal Ollama)
 ```
@@ -405,7 +405,7 @@ npm run smoke:gpu     # GPU compose (internal Ollama)
 UI smoke with Playwright (brings up frontend + backend, runs headless tests):
 
 ```bash
-cd PMOVES_DoX
+cd PMOVES-DoX
 npm run smoke:ui       # CPU compose
 npm run smoke:ui:gpu   # GPU compose
 ```
@@ -413,13 +413,13 @@ npm run smoke:ui:gpu   # GPU compose
 Run the Python smoke directly against a running backend:
 
 ```bash
-cd PMOVES_DoX
+cd PMOVES-DoX
 API_BASE=http://localhost:8000 python smoke/smoke_backend.py
 ```
 
 ## MCP Usage (starter)
 
-An MCP manifest is provided for PMOVES_DoX tools (search, extract_tags, export_poml):
+An MCP manifest is provided for PMOVES-DoX tools (search, extract_tags, export_poml):
 
 - Path: `backend/mcp/manifest.json`
 - Tools:
@@ -488,7 +488,7 @@ Copilot Studio / POML
 Option A — use Docker from the script (recommended):
 
 ```powershell
-cd PMOVES_DoX
+cd PMOVES-DoX
 $env:SMOKE_COMPOSE = 'docker-compose.cpu.yml'    # or 'docker-compose.yml' for GPU
 python -m venv venv; ./venv/Scripts/Activate.ps1
 pip install -r smoke/requirements.txt requests
@@ -498,7 +498,7 @@ python smoke/run_smoke_docker.py
 Option B — run against an already running backend:
 
 ```powershell
-cd PMOVES_DoX
+cd PMOVES-DoX
 python -m venv venv; ./venv/Scripts/Activate.ps1
 pip install -r smoke/requirements.txt
 $env:API_BASE = 'http://localhost:8000'
@@ -553,7 +553,7 @@ To include https://github.com/google/mangle in your workflow, run it alongside t
 go install github.com/google/mangle/cmd/mangle@latest
 
 # Transform a CSV and drop into watch folder for auto-ingest
-mangle run your.mangle -i path\to\input.csv -o PMOVES_DoX\watch\transformed.csv
+mangle run your.mangle -i path\to\input.csv -o PMOVES-DoX\watch\transformed.csv
 ```
 
 You can also add a custom container for mangle later if you prefer containerized transforms.
@@ -563,7 +563,7 @@ You can also add a custom container for mangle later if you prefer containerized
 SQLite is used by default (`db.sqlite3`). Alembic scaffolding is included:
 
 ```powershell
-cd PMOVES_DoX/backend
+cd PMOVES-DoX/backend
 alembic upgrade head           # apply migrations (none initially)
 alembic revision --autogenerate -m "init"  # create a new migration from current SQLModel metadata
 alembic upgrade head

--- a/backend/app/export_poml.py
+++ b/backend/app/export_poml.py
@@ -23,15 +23,15 @@ def build_poml(
     # Role + system guidance
     if variant == "troubleshoot":
         lines.append("  <role>You are a pragmatic SRE for an LMS platform. Diagnose succinctly with evidence.</role>")
-        lines.append("  <system-msg>PMOVES_DoX troubleshooting mode: prioritize error codes, components, timestamps, and likely root causes.</system-msg>")
+        lines.append("  <system-msg>PMOVES-DoX troubleshooting mode: prioritize error codes, components, timestamps, and likely root causes.</system-msg>")
         lines.append(f"  <task>Identify causes and fixes related to: {title}. Use logs, APIs, and tags to justify answers.</task>")
     elif variant == "catalog":
         lines.append("  <role>You are a precise technical writer. Generate concise catalogs from source artifacts.</role>")
-        lines.append("  <system-msg>PMOVES_DoX catalog mode: summarize APIs, key tags, and references for quick discovery.</system-msg>")
+        lines.append("  <system-msg>PMOVES-DoX catalog mode: summarize APIs, key tags, and references for quick discovery.</system-msg>")
         lines.append(f"  <task>Produce a compact catalog for: {title}. Include endpoint summaries and notable tags.</task>")
     else:
         lines.append("  <role>You are a precise analyst. Prefer terse answers with citations.</role>")
-        lines.append("  <system-msg>PMOVES_DoX: document analysis and structured extraction for LMS/enterprise artifacts.</system-msg>")
+        lines.append("  <system-msg>PMOVES-DoX: document analysis and structured extraction for LMS/enterprise artifacts.</system-msg>")
         lines.append(f"  <task>Answer questions about: {title}. Use provided APIs, tags, logs, and tables as sources.</task>")
 
     # Optional resources: document (markdown) and CHR table

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,7 +48,7 @@ hf_token = (
 if hf_token and not os.getenv("HUGGINGFACE_HUB_TOKEN"):
     os.environ["HUGGINGFACE_HUB_TOKEN"] = hf_token
 
-app = FastAPI(title="PMOVES_DoX API")
+app = FastAPI(title="PMOVES-DoX API")
 
 # Optionally run Alembic migrations on startup
 if os.getenv("AUTO_MIGRATE", "false").lower() == "true":
@@ -208,7 +208,7 @@ async def _startup_watch():
 
 @app.get("/")
 async def root():
-    return {"message": "PMOVES_DoX API", "status": "running"}
+    return {"message": "PMOVES-DoX API", "status": "running"}
 
 @app.get("/config")
 async def config():

--- a/backend/mcp/manifest.json
+++ b/backend/mcp/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "name_for_human": "PMOVES_DoX",
+  "name_for_human": "PMOVES-DoX",
   "name_for_model": "pmoves_dox",
   "description_for_model": "Document ingestion, vector search, tag extraction, and POML export tools.",
   "capabilities": {

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,4 +1,4 @@
-# Next Steps Plan (PMOVES_DoX)
+# Next Steps Plan (PMOVES-DoX)
 
 ## Goals
 - Ingest + structure LMS Admin Guides (PDF), XML logs, and API collections
@@ -98,7 +98,7 @@
 - API detail modal; Logs time filters + CSV export (DONE)
 - CHR controls + richer PCA; datavzrd themes/spells
 - DB indexes; Alembic auto‑run; nightly GPU smoke
-- Docs walkthroughs + screencasts (update with PMOVES_DoX branding)
+- Docs walkthroughs + screencasts (update with PMOVES-DoX branding)
 
 ## HRM/Reasoning Enhancements
 - Sidecar HRM for iterative refinement

--- a/docs/SUPABASE_MIGRATION.md
+++ b/docs/SUPABASE_MIGRATION.md
@@ -1,7 +1,7 @@
 # Supabase Migration Plan
 
 ## Overview
-Migrate PMOVES_DoX backend persistence from the local SQLite layer (`ExtendedDatabase`) to Supabase (managed Postgres + `pgvector`) while keeping feature parity for ingestion, tagging, search, and HRM metrics. The migration must preserve existing APIs and enable advanced LangExtract/Docling workflows across heterogeneous hardware (RTX 50-series, Jetson Orin, mobile edge devices) by delegating storage and vector math to Supabase where possible.
+Migrate PMOVES-DoX backend persistence from the local SQLite layer (`ExtendedDatabase`) to Supabase (managed Postgres + `pgvector`) while keeping feature parity for ingestion, tagging, search, and HRM metrics. The migration must preserve existing APIs and enable advanced LangExtract/Docling workflows across heterogeneous hardware (RTX 50-series, Jetson Orin, mobile edge devices) by delegating storage and vector math to Supabase where possible.
 
 ## Environment & Tooling
 - **Credentials**: define `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_KEY` as env vars (service key stored outside git; use local `.env` only).

--- a/docs/branding_alignment_tasks.md
+++ b/docs/branding_alignment_tasks.md
@@ -1,0 +1,21 @@
+# PMOVES-DoX Branding Alignment Tasks
+
+## Context
+A repository-wide audit was performed to remove the remaining “meeting app” references and to refresh the visible product copy with the PMOVES-DoX positioning (“The ultimate document structured data extraction and analysis tool…”). The items below capture the next pieces of work needed to finish the branding transition.
+
+## Backlog
+- **Frontend assets**
+  - Replace the default Next.js favicon / app icons with PMOVES-DoX artwork so browser tabs and PWA installs pick up the new branding.
+  - Add OpenGraph/Twitter metadata (title, description, preview image) that mirrors the new tagline for richer link unfurls.
+  - Review empty states, toasts, and settings copy for residual LMS- or meeting-specific wording and update to the PMOVES-DoX voice.
+- **Backend & services**
+  - Standardize structured log prefixes and telemetry emitted from the FastAPI app so dashboards show “PMOVES-DoX” consistently.
+  - Update any scheduled jobs or Celery task names (e.g., when Celery is re-enabled) to drop legacy identifiers.
+- **Docs & onboarding**
+  - Refresh the Windows `setup.ps1` prompts and README screenshots once new logos/artifacts exist.
+  - Produce a quickstart Loom/screencast that walks through the PMOVES-DoX UI and features (references in `docs/NEXT_STEPS.md`).
+- **Distribution**
+  - Verify Docker image tags, Supabase project metadata, and future release notes use the PMOVES-DoX name for marketplace publishing.
+
+## Notes
+Keep this checklist updated as new surfaces are branded so the next pass can verify the rename is complete end-to-end.

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -6,8 +6,8 @@ import { ToastProvider, ToastViewport } from '@/components/Toast'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'PMOVES_DoX',
-  description: 'Ultimate document structured data extraction, analysis, transform and visualization',
+  title: 'PMOVES-DoX',
+  description: 'The ultimate document structured data extraction and analysis tool for PDFs, XML logs, CSV/XLSX, and OpenAPI/Postman collections.',
 }
 
 export default function RootLayout({

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -84,7 +84,9 @@ export default function Home() {
             Processing PDFs in background: {queuedCount} file(s)…
           </div>
         )}
-        <p className="text-gray-600 mb-4">Upload LMS docs (PDF), XML logs, and API collections; structure, tag, search, and visualize.</p>
+        <h1 className="text-3xl font-semibold text-gray-900 mb-2">PMOVES-DoX</h1>
+        <p className="text-gray-600 mb-3">The ultimate document structured data extraction and analysis tool.</p>
+        <p className="text-gray-500 mb-6">Extract, analyze, transform, and visualize data from PDFs, XML logs, CSV/XLSX, and OpenAPI/Postman collections. Local-first with Hugging Face + Ollama; ships as standalone, Docker, and MS Teams Copilot/MCP-friendly.</p>
 
         <div className="mb-6 flex gap-2">
           {(['workspace','logs','apis','tags','artifacts'] as const).map(t => (

--- a/frontend/components/HeaderBar.tsx
+++ b/frontend/components/HeaderBar.tsx
@@ -68,7 +68,7 @@ export default function HeaderBar() {
   return (
     <div className="sticky top-0 z-30 bg-white/90 backdrop-blur border-b">
       <div className="max-w-7xl mx-auto flex items-center gap-3 p-3">
-        <div className="font-semibold text-lg flex items-center gap-2">PMOVES_DoX {hrm && (<span title="HRM Sidecar enabled" className="text-[10px] px-2 py-0.5 rounded-full bg-purple-100 text-purple-700 border border-purple-200">HRM</span>)}
+        <div className="font-semibold text-lg flex items-center gap-2">PMOVES-DoX {hrm && (<span title="HRM Sidecar enabled" className="text-[10px] px-2 py-0.5 rounded-full bg-purple-100 text-purple-700 border border-purple-200">HRM</span>)}
           {deeplinkInfo && (
             <>
               <span className="ml-2 text-[10px] px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Last deeplink target">{deeplinkInfo}</span>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "meeting-analyst-frontend",
+  "name": "pmoves-dox-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "meeting-analyst-frontend",
+      "name": "pmoves-dox-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@types/node": "^20.11.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "meeting-analyst-frontend",
+  "name": "pmoves-dox-frontend",
   "version": "0.1.0",
+  "description": "PMOVES-DoX frontend for document data extraction and analysis",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "lms-analyst-repo",
+  "name": "pmoves-dox-monorepo",
   "private": true,
+  "description": "PMOVES-DoX monorepo scripts and smoke test runners",
   "scripts": {
     "smoke": "node tools/run-smoke.js",
     "smoke:cpu": "node tools/run-smoke.js cpu",

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,8 +1,8 @@
-# LMS Analyst - Quick Setup Script for Windows
+# PMOVES-DoX - Quick Setup Script for Windows
 # Run this script in PowerShell to set up both backend and frontend
 
 Write-Host "==================================" -ForegroundColor Cyan
-Write-Host "LMS Analyst - Setup Script" -ForegroundColor Cyan
+Write-Host "PMOVES-DoX - Setup Script" -ForegroundColor Cyan
 Write-Host "==================================" -ForegroundColor Cyan
 Write-Host ""
 

--- a/ui-smoke/tests/app.spec.ts
+++ b/ui-smoke/tests/app.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test('loads header and basic tabs', async ({ page }) => {
   await page.goto('/');
-  await expect(page.locator('text=PMOVES_DoX')).toBeVisible();
+  await expect(page.locator('text=PMOVES-DoX')).toBeVisible();
   // search is present
   const search = page.getByPlaceholder('Search docs, APIs, logs, tags…');
   await expect(search).toBeVisible();


### PR DESCRIPTION
## Summary
- update the frontend header, metadata, and hero copy to present the PMOVES-DoX name and tagline
- rename package metadata, backend responses, scripts, and docs to replace the remaining meeting-app references
- document follow-up branding tasks for assets, telemetry, onboarding, and release pipelines

## Testing
- `npm run lint` *(fails: next not found in container image)*

------
https://chatgpt.com/codex/tasks/task_b_68e5292e32548324a74b1229605fe69a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Rebranded app from PMOVES_DoX to PMOVES-DoX across UI, API title, and headers.
  - Updated landing page messaging and app metadata description for clearer capabilities.

- Documentation
  - Updated all docs to reflect new PMOVES-DoX naming and paths.
  - Added branding alignment task document to guide transition.

- Chores
  - Renamed packages and added project descriptions.
  - Added smoke test scripts and aligned setup script banner text.

- Tests
  - Updated UI smoke test to validate new header branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->