### PR TITLE
Fix heuristic tag regex and add regression test

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -452,7 +452,7 @@ async def extract_tags(req: ExtractTagsRequest):
     t0 = time.time()
     def _heuristic_entities(limit: int = 5):
         import re as _re
-        candidates = _re.findall(r"([A-Z][a-z]+(?:\s+[A-Z][a-zA-Z]+){0,2})", text)
+        candidates = _re.findall(r"([A-Z][a-z]+(?:\s+[A-Z][a-zA-Z]+){0,2})", text)
         unique = []
         for c in candidates:
             c = c.strip()

--- a/backend/tests/test_extract_tags.py
+++ b/backend/tests/test_extract_tags.py
@@ -1,0 +1,49 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+for _path in (str(_REPO_ROOT), str(_BACKEND_DIR)):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+from backend.app import main
+
+
+class _StubDB:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def list_documents(self):
+        return list(self._docs)
+
+
+def test_extract_tags_heuristic_dry_run(monkeypatch, tmp_path):
+    doc_path = tmp_path / "doc.txt"
+    doc_path.write_text(
+        "Loan Origination Platform\nUnderwriting Module\n",
+        encoding="utf-8",
+    )
+
+    stub_db = _StubDB([
+        {"id": "doc-1", "type": "txt", "path": str(doc_path)}
+    ])
+    monkeypatch.setattr(main, "db", stub_db)
+
+    for env_key in ("GOOGLE_API_KEY", "OPENAI_API_KEY", "LANGEXTRACT_API_KEY"):
+        monkeypatch.delenv(env_key, raising=False)
+
+    def _fail_run_langextract(*args, **kwargs):
+        raise AssertionError("run_langextract should not be called in heuristic dry-run")
+
+    monkeypatch.setattr(main, "run_langextract", _fail_run_langextract)
+
+    req = main.ExtractTagsRequest(document_id="doc-1", dry_run=True)
+    result = asyncio.run(main.extract_tags(req))
+
+    assert result["status"] == "ok"
+    assert {"Loan Origination Platform", "Underwriting Module"}.issubset(set(result["tags"]))
+    assert result["tags_saved"] == 0


### PR DESCRIPTION
## Summary
- correct the heuristic tag extraction regex to use a valid raw string literal
- add a regression test covering the dry-run fallback path so it returns heuristic tags without external credentials

## Testing
- pytest backend/tests/test_extract_tags.py

------
https://chatgpt.com/codex/tasks/task_b_68e7971ca05c8324b11d041302020940

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tag extraction heuristics to better recognize capitalized entities. This may slightly change which phrases are detected and improve relevance of suggested tags in both dry-run and normal use.

* **Tests**
  * Added tests for the Extract Tags dry-run flow to confirm expected tags are returned, no external services are called, and no tags are saved, improving stability and confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->