### PR TITLE
Refresh panel API base lookups

### DIFF
--- a/frontend/components/ArtifactsPanel.tsx
+++ b/frontend/components/ArtifactsPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Fragment, useEffect, useState } from 'react';
+import { getApiBase } from '@/lib/config';
 import { useToast } from '@/components/Toast';
 
 export default function ArtifactsPanel() {
@@ -9,11 +10,11 @@ export default function ArtifactsPanel() {
   const [detail, setDetail] = useState<any | null>(null);
   const [analysis, setAnalysis] = useState<any | null>(null);
   const [opts, setOpts] = useState<Record<string, any>>({});
-  const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
   const { push } = useToast();
 
   const load = async () => {
-    const r = await fetch(`${API}/artifacts`);
+    const apiBase = getApiBase();
+    const r = await fetch(`${apiBase}/artifacts`);
     if (!r.ok) return;
     const data = await r.json();
     setArtifacts(Array.isArray(data.artifacts) ? data.artifacts : []);
@@ -24,24 +25,27 @@ export default function ArtifactsPanel() {
   const structure = async (id: string) => {
     setBusy(id);
     try {
-      await fetch(`${API}/structure/chr`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ artifact_id: id, K: 8 }) });
+      const apiBase = getApiBase();
+      await fetch(`${apiBase}/structure/chr`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ artifact_id: id, K: 8 }) });
     } finally { setBusy(null); }
   };
 
   const convert = async (id: string, fmt: 'txt'|'docx') => {
     setBusy(id+fmt);
     try {
-      const r = await fetch(`${API}/convert`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ artifact_id: id, format: fmt }) });
+      const apiBase = getApiBase();
+      const r = await fetch(`${apiBase}/convert`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ artifact_id: id, format: fmt }) });
       if (!r.ok) return;
       const data = await r.json();
-      if (data.rel) window.open(`${API}/download?rel=${encodeURIComponent(data.rel)}`, '_blank');
+      if (data.rel) window.open(`${apiBase}/download?rel=${encodeURIComponent(data.rel)}`, '_blank');
     } finally { setBusy(null); }
   };
 
   const chrViz = async (id: string) => {
     setBusy(id+'viz');
     try {
-      const r = await fetch(`${API}/viz/datavzrd`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ artifact_id: id }) });
+      const apiBase = getApiBase();
+      const r = await fetch(`${apiBase}/viz/datavzrd`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ artifact_id: id }) });
       if (r.ok) alert('CHR datavzrd project generated. Open http://localhost:5173');
     } finally { setBusy(null); }
   };
@@ -57,7 +61,8 @@ export default function ArtifactsPanel() {
       if (o.mangleFile) body.mangle_file = String(o.mangleFile);
       if (o.mangleQuery) body.mangle_query = String(o.mangleQuery);
       if (o.pomlVariant) body.poml_variant = String(o.pomlVariant);
-      const r = await fetch(`${API}/autotag/${id}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+      const apiBase = getApiBase();
+      const r = await fetch(`${apiBase}/autotag/${id}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
       const contentType = r.headers.get('content-type') || '';
       const payload = contentType.includes('application/json') ? await r.json() : await r.text();
       if (!r.ok) {
@@ -86,9 +91,10 @@ export default function ArtifactsPanel() {
   };
 
   const openDetail = async (id: string) => {
+    const apiBase = getApiBase();
     const [detailRes, analysisRes] = await Promise.all([
-      fetch(`${API}/artifacts/${id}`),
-      fetch(`${API}/analysis/artifacts/${id}`)
+      fetch(`${apiBase}/artifacts/${id}`),
+      fetch(`${apiBase}/analysis/artifacts/${id}`)
     ]);
     if (!detailRes.ok) return;
     setDetail(await detailRes.json());
@@ -299,7 +305,7 @@ export default function ArtifactsPanel() {
                     <div className="font-medium mb-1">Charts ({analysis.charts?.length || 0})</div>
                     <div className="space-y-3">
                       {(analysis.charts||[]).map((chart:any)=>{
-                        const imageSrc = chart.image_path ? `${API}/download?rel=${encodeURIComponent(chart.image_path)}` : null;
+                        const imageSrc = chart.image_path ? `${getApiBase()}/download?rel=${encodeURIComponent(chart.image_path)}` : null;
                         return (
                           <div key={chart.id || chart.locator} className="border rounded p-2 bg-gray-50">
                             <div className="flex flex-col text-xs gap-1 mb-2">

--- a/frontend/components/CHRPanel.tsx
+++ b/frontend/components/CHRPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
+import { getApiBase } from '@/lib/config';
 
 export default function CHRPanel() {
   const [artifactId, setArtifactId] = useState('');
@@ -21,12 +22,12 @@ export default function CHRPanel() {
   const [hrmDigits, setHrmDigits] = useState('93241');
   const [hrmTrace, setHrmTrace] = useState<string[] | null>(null);
   const [hrmSteps, setHrmSteps] = useState<number | null>(null);
-  const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
 
   useEffect(() => {
     (async () => {
       try {
-        const r = await fetch(`${API}/artifacts`);
+        const apiBase = getApiBase();
+        const r = await fetch(`${apiBase}/artifacts`);
         if (!r.ok) return;
         const data = await r.json();
         setArtifacts(Array.isArray(data.artifacts) ? data.artifacts : []);
@@ -35,7 +36,8 @@ export default function CHRPanel() {
     // fetch config for OPEN_PDF_ENABLED
     (async () => {
       try {
-        const r = await fetch(`${API}/config`);
+        const apiBase = getApiBase();
+        const r = await fetch(`${apiBase}/config`);
         if (!r.ok) return;
         const cfg = await r.json();
         setOpenPdfEnabled(!!cfg?.open_pdf_enabled);
@@ -47,7 +49,8 @@ export default function CHRPanel() {
     if (!artifactId.trim()) return;
     setBusy(true);
     try {
-      const res = await fetch(`${API}/structure/chr`, {
+      const apiBase = getApiBase();
+      const res = await fetch(`${apiBase}/structure/chr`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ artifact_id: artifactId.trim(), K })
@@ -67,7 +70,8 @@ export default function CHRPanel() {
     setConvertBusy(true);
     setConvertRel(null);
     try {
-      const res = await fetch(`${API}/convert`, {
+      const apiBase = getApiBase();
+      const res = await fetch(`${apiBase}/convert`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ artifact_id: artifactId.trim(), format: convertFormat })
@@ -87,7 +91,8 @@ export default function CHRPanel() {
     setVizBusy(true);
     setVizRel(null);
     try {
-      const res = await fetch(`${API}/viz/datavzrd`, {
+      const apiBase = getApiBase();
+      const res = await fetch(`${apiBase}/viz/datavzrd`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ artifact_id: artifactId.trim(), title: `CHR – ${artifactId.trim().slice(0,8)}...` })
@@ -107,7 +112,8 @@ export default function CHRPanel() {
   const runHRMDemo = async () => {
     setHrmTrace(null); setHrmSteps(null);
     try {
-      const res = await fetch(`${API}/experiments/hrm/sort_digits`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ seq: hrmDigits }) });
+      const apiBase = getApiBase();
+      const res = await fetch(`${apiBase}/experiments/hrm/sort_digits`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ seq: hrmDigits }) });
       if (!res.ok) throw new Error('hrm demo failed');
       const data = await res.json();
       setHrmTrace(Array.isArray(data.trace) ? data.trace : []);
@@ -145,7 +151,7 @@ export default function CHRPanel() {
       <h2 className="text-2xl font-bold mb-2">Structure (CHR)</h2>
       {artifactId && pageNum!=null && openPdfEnabled && (
         <div className="mb-2 text-xs">
-          <a className="text-blue-700 underline" href={`${API}/open/pdf?artifact_id=${encodeURIComponent(artifactId)}#page=${pageNum}`} target="_blank">Open PDF at page</a>
+          <a className="text-blue-700 underline" href={`${getApiBase()}/open/pdf?artifact_id=${encodeURIComponent(artifactId)}#page=${pageNum}`} target="_blank">Open PDF at page</a>
         </div>
       )}
       <div className="space-y-4">
@@ -195,13 +201,13 @@ export default function CHRPanel() {
             {pageNum!=null && (<div className="mt-1 text-xs text-gray-700">Approx. page: {pageNum}</div>)}
             {artifactId && pageNum!=null && openPdfEnabled && (
               <div className="mt-1 text-xs">
-                <a className="text-blue-700 underline" href={`${API}/open/pdf?artifact_id=${encodeURIComponent(artifactId)}#page=${pageNum}`} target="_blank">Open PDF at page</a>
+                <a className="text-blue-700 underline" href={`${getApiBase()}/open/pdf?artifact_id=${encodeURIComponent(artifactId)}#page=${pageNum}`} target="_blank">Open PDF at page</a>
               </div>
             )}
           </div>
           {result.artifacts?.rel_plot && (
             <div>
-              <img src={`${API}/download?rel=${encodeURIComponent(result.artifacts.rel_plot)}`} alt="CHR PCA" className="border rounded" />
+              <img src={`${getApiBase()}/download?rel=${encodeURIComponent(result.artifacts.rel_plot)}`} alt="CHR PCA" className="border rounded" />
             </div>
           )}
           {Array.isArray(result.preview_rows) && result.preview_rows.length > 0 && (
@@ -241,7 +247,7 @@ export default function CHRPanel() {
               <div className="flex items-center gap-2">
                 <span className="font-medium">CSV:</span>
                 {result.artifacts.rel_csv ? (
-                  <a className="text-blue-600 hover:underline" href={`${API}/download?rel=${encodeURIComponent(result.artifacts.rel_csv)}`}>Download</a>
+                  <a className="text-blue-600 hover:underline" href={`${getApiBase()}/download?rel=${encodeURIComponent(result.artifacts.rel_csv)}`}>Download</a>
                 ) : (
                   <span>{result.artifacts.csv}</span>
                 )}
@@ -249,7 +255,7 @@ export default function CHRPanel() {
               <div className="flex items-center gap-2">
                 <span className="font-medium">JSON:</span>
                 {result.artifacts.rel_json ? (
-                  <a className="text-blue-600 hover:underline" href={`${API}/download?rel=${encodeURIComponent(result.artifacts.rel_json)}`}>Download</a>
+                  <a className="text-blue-600 hover:underline" href={`${getApiBase()}/download?rel=${encodeURIComponent(result.artifacts.rel_json)}`}>Download</a>
                 ) : (
                   <span>{result.artifacts.json}</span>
                 )}
@@ -270,7 +276,7 @@ export default function CHRPanel() {
             {convertBusy ? 'Converting…' : 'Convert'}
           </button>
           {convertRel && (
-            <a className="text-blue-600 hover:underline" href={`${API}/download?rel=${encodeURIComponent(convertRel)}`}>Download</a>
+            <a className="text-blue-600 hover:underline" href={`${getApiBase()}/download?rel=${encodeURIComponent(convertRel)}`}>Download</a>
           )}
         </div>
       </div>

--- a/frontend/components/EntitiesPanel.tsx
+++ b/frontend/components/EntitiesPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
+import { getApiBase } from '@/lib/config';
 
 type DocumentItem = {
   id: string;
@@ -21,8 +22,6 @@ type Props = {
   refreshKey: number;
 };
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
-
 export default function EntitiesPanel({ refreshKey }: Props) {
   const [documents, setDocuments] = useState<DocumentItem[]>([]);
   const [selected, setSelected] = useState<string>('');
@@ -33,6 +32,7 @@ export default function EntitiesPanel({ refreshKey }: Props) {
   useEffect(() => {
     const loadDocuments = async () => {
       try {
+        const API = getApiBase();
         const res = await axios.get(`${API}/documents`, { params: { type: 'pdf' } });
         const docs = (res.data?.documents || []) as DocumentItem[];
         setDocuments(docs);
@@ -59,6 +59,7 @@ export default function EntitiesPanel({ refreshKey }: Props) {
       setLoading(true);
       setError(null);
       try {
+        const API = getApiBase();
         const res = await axios.get(`${API}/analysis/entities`, { params: { document_id: selected } });
         if (!cancelled) {
           setEntities((res.data?.entities || []) as EntityRow[]);

--- a/frontend/components/FactsViewer.tsx
+++ b/frontend/components/FactsViewer.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
+import { getApiBase } from '@/lib/config';
 
 export default function FactsViewer() {
   const [facts, setFacts] = useState<any[]>([]);
@@ -20,7 +21,7 @@ export default function FactsViewer() {
 
   const loadFacts = async (silent = false) => {
     try {
-      const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+      const API = getApiBase();
       const [factsResponse, financialsResponse] = await Promise.all([
         axios.get(`${API}/facts`),
         axios.get(`${API}/analysis/financials`),

--- a/frontend/components/MetricHitsPanel.tsx
+++ b/frontend/components/MetricHitsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import axios from 'axios';
+import { getApiBase } from '@/lib/config';
 
 type DocumentItem = {
   id: string;
@@ -21,8 +22,6 @@ type Props = {
   refreshKey: number;
 };
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
-
 export default function MetricHitsPanel({ refreshKey }: Props) {
   const [documents, setDocuments] = useState<DocumentItem[]>([]);
   const [selected, setSelected] = useState<string>('');
@@ -33,6 +32,7 @@ export default function MetricHitsPanel({ refreshKey }: Props) {
   useEffect(() => {
     const loadDocuments = async () => {
       try {
+        const API = getApiBase();
         const res = await axios.get(`${API}/documents`, { params: { type: 'pdf' } });
         const docs = (res.data?.documents || []) as DocumentItem[];
         setDocuments(docs);
@@ -59,6 +59,7 @@ export default function MetricHitsPanel({ refreshKey }: Props) {
       setLoading(true);
       setError(null);
       try {
+        const API = getApiBase();
         const res = await axios.get(`${API}/analysis/metrics`, { params: { document_id: selected } });
         if (!cancelled) {
           setHits((res.data?.metric_hits || []) as MetricHit[]);

--- a/frontend/components/StructurePanel.tsx
+++ b/frontend/components/StructurePanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
+import { getApiBase } from '@/lib/config';
 
 type DocumentItem = {
   id: string;
@@ -25,8 +26,6 @@ type Props = {
   refreshKey: number;
 };
 
-const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
-
 export default function StructurePanel({ refreshKey }: Props) {
   const [documents, setDocuments] = useState<DocumentItem[]>([]);
   const [selected, setSelected] = useState<string>('');
@@ -37,6 +36,7 @@ export default function StructurePanel({ refreshKey }: Props) {
   useEffect(() => {
     const loadDocuments = async () => {
       try {
+        const API = getApiBase();
         const res = await axios.get(`${API}/documents`, { params: { type: 'pdf' } });
         const docs = (res.data?.documents || []) as DocumentItem[];
         setDocuments(docs);
@@ -63,6 +63,7 @@ export default function StructurePanel({ refreshKey }: Props) {
       setLoading(true);
       setError(null);
       try {
+        const API = getApiBase();
         const res = await axios.get(`${API}/analysis/structure`, { params: { document_id: selected } });
         if (!cancelled) {
           setStructure((res.data?.structure || null) as StructurePayload | null);

--- a/frontend/components/SummariesPanel.tsx
+++ b/frontend/components/SummariesPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getApiBase } from '@/lib/config';
 import { useToast } from '@/components/Toast';
 
 type SummaryStyle = 'bullet' | 'executive' | 'action_items';
@@ -34,7 +35,6 @@ const STYLE_LABELS: Record<SummaryStyle, string> = {
 };
 
 export default function SummariesPanel() {
-  const API = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
   const { push } = useToast();
   const [style, setStyle] = useState<SummaryStyle>('bullet');
   const [scope, setScope] = useState<SummaryScope>('workspace');
@@ -51,7 +51,8 @@ export default function SummariesPanel() {
 
   const loadArtifacts = useCallback(async () => {
     try {
-      const resp = await fetch(`${API}/artifacts`);
+      const apiBase = getApiBase();
+      const resp = await fetch(`${apiBase}/artifacts`);
       if (!resp.ok) return;
       const data = await resp.json();
       const rows = Array.isArray(data?.artifacts) ? data.artifacts : [];
@@ -59,7 +60,7 @@ export default function SummariesPanel() {
     } catch {
       // ignore fetch errors for now
     }
-  }, [API]);
+  }, []);
 
   const loadHistory = useCallback(async () => {
     if (scope === 'artifact' && selected.length === 0) {
@@ -72,7 +73,8 @@ export default function SummariesPanel() {
       params.append('scope', 'artifact');
     }
     try {
-      const resp = await fetch(`${API}/summaries?${params.toString()}`);
+      const apiBase = getApiBase();
+      const resp = await fetch(`${apiBase}/summaries?${params.toString()}`);
       if (!resp.ok) return;
       const data = await resp.json();
       const items: SummaryRecord[] = Array.isArray(data?.summaries) ? data.summaries : [];
@@ -84,7 +86,7 @@ export default function SummariesPanel() {
     } catch {
       // ignore errors during history fetch
     }
-  }, [API, scope, selected, scopeKey, style]);
+  }, [scope, selected, scopeKey, style]);
 
   useEffect(() => {
     loadArtifacts();
@@ -124,7 +126,8 @@ export default function SummariesPanel() {
       if (scope === 'artifact') {
         body.artifact_ids = [...selected];
       }
-      const resp = await fetch(`${API}/summaries/generate`, {
+      const apiBase = getApiBase();
+      const resp = await fetch(`${apiBase}/summaries/generate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
- remove stale apiBase instances in ArtifactsPanel and use getApiBase for chart downloads
- update CHRPanel links and downloads to resolve the API base at render time instead of caching

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6925f0841e5883249f408d7467b3a481)