### PR TITLE
fix(ci): remove incorrect working-directory references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           python-version: '3.11'
       - name: Build backend (CPU)
-        working-directory: PMOVES_DoX
         env:
           AUTO_MIGRATE: 'true'
           HRM_ENABLED: 'true'
@@ -24,7 +23,6 @@ jobs:
         run: |
           docker compose -f docker-compose.cpu.yml build backend
       - name: Run backend
-        working-directory: PMOVES_DoX
         env:
           AUTO_MIGRATE: 'true'
           HRM_ENABLED: 'true'
@@ -35,18 +33,15 @@ jobs:
         run: |
           for i in {1..30}; do curl -fsS http://localhost:8000/health && exit 0 || sleep 2; done; exit 1
       - name: Install smoke deps
-        working-directory: PMOVES_DoX
         run: |
           python -m pip install --upgrade pip
           pip install -r smoke/requirements.txt
       - name: Run smoke
-        working-directory: PMOVES_DoX
         env:
           API_BASE: http://localhost:8000
         run: python smoke/smoke_backend.py
       - name: Teardown
         if: always()
-        working-directory: PMOVES_DoX
         run: docker compose -f docker-compose.cpu.yml down -v
 
   smoke-gpu:
@@ -59,12 +54,10 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install smoke deps
-        working-directory: PMOVES_DoX
         run: |
           python -m pip install --upgrade pip
           pip install -r smoke/requirements.txt requests
       - name: Run GPU smoke via docker compose
-        working-directory: PMOVES_DoX
         env:
           SMOKE_COMPOSE: docker-compose.yml
           SMOKE_FLAGS: --compatibility
@@ -85,7 +78,6 @@ jobs:
         with:
           node-version: '20'
       - name: Run UI smoke (CPU)
-        working-directory: PMOVES_DoX
         env:
           AUTO_MIGRATE: 'true'
           HRM_ENABLED: 'true'


### PR DESCRIPTION
## Summary

Fixes CI workflow that was incorrectly referencing `PMOVES_DoX` as a working directory. The repository structure has files at root level (`docker-compose.cpu.yml`, `smoke/`, `backend/`), not in a subdirectory.

## Problem

The CI workflow had:
```yaml
working-directory: PMOVES_DoX
run: docker compose -f docker-compose.cpu.yml build backend
```

But `PMOVES_DoX/` subdirectory doesn't exist - files are at root.

## Changes

- Removed all `working-directory: PMOVES_DoX` references (8 occurrences)
- Jobs now run from repository root where files actually exist

## Impact

This fix should resolve the smoke test failures for PRs #35 and #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI workflow configuration for improved execution efficiency across automated checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->