### PR TITLE
fix(config): Add DB_BACKEND and Supabase credentials to backend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
       - ../pmoves/env.shared
       - .env.local
     environment:
+      - DB_BACKEND=supabase
       - DATABASE_URL=postgresql://postgres:postgres@supabase-db:5432/postgres
+      - SUPABASE_URL=http://supabase-rest:3000
+      - SUPABASE_SERVICE_KEY=${PGRST_JWT_SECRET}
       - REDIS_URL=redis://redis:6379
       - NATS_URL=nats://nats:4222
       - FRONTEND_ORIGIN=http://localhost:8484,http://127.0.0.1:8484,http://frontend:3001


### PR DESCRIPTION
## Problem

The backend service was defaulting to SQLite instead of using the configured Supabase (PostgreSQL) database due to missing environment variables.

**Root Cause:** `backend/app/database_factory.py:69` checks `DB_BACKEND` environment variable:
- If not set → defaults to SQLite
- If set to `supabase` → uses Supabase (PostgreSQL)

This caused:
- ❌ Skills endpoint returning empty (skills stored in Supabase not accessible)
- ❌ Loss of Supabase/Neo4j integration features from PR #38
- ❌ Database operations using wrong backend

## Solution

Added three critical environment variables to backend service in `docker-compose.yml`:

1. **DB_BACKEND=supabase** - Tells database factory to use Supabase instead of SQLite
2. **SUPABASE_URL=http://supabase-rest:3000** - Points to PostgREST service for Supabase REST API  
3. **SUPABASE_SERVICE_KEY=${PGRST_JWT_SECRET}** - JWT authentication using PostgREST secret

## Changes

- Modified `docker-compose.yml` backend service environment section
- Added 3 new environment variables (lines 18-21)

## Testing

After applying this fix:
1. Backend connects to Supabase instead of SQLite
2. Skills endpoint should return registered skills from Supabase
3. Neo4j and Supabase integrations from PR #38 work correctly

## Related Issues

- Resolves skills endpoint empty issue
- Resolves database backend selection defaulting to SQLite
- Completes database configuration from PR #38 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend database configuration to support Supabase integration with PostgREST service connectivity through new environment variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->