### PR TITLE
fix(cipher): Correct skills endpoint method name

### DIFF
--- a/backend/app/api/routers/cipher.py
+++ b/backend/app/api/routers/cipher.py
@@ -55,7 +55,7 @@ def search_memory(q: Optional[str] = None, category: Optional[str] = None):
 @router.get("/skills")
 def get_skills():
     service = CipherService()
-    return service.list_available_skills()
+    return service.list_skills()
 
 @router.put("/skills/{skill_id}")
 async def toggle_skill(skill_id: str, enabled: bool, db=Depends(get_db_interface)):


### PR DESCRIPTION
## Problem

The cipher router's skills endpoint was calling a non-existent method, causing the endpoint to fail.

**Root Cause:** `backend/app/api/routers/cipher.py:58` calls `service.list_available_skills()` but:
- ❌ `CipherService` does NOT have `list_available_skills()` method
- ✅ `CipherService` DOES have `list_skills()` method (line 30)

This caused:
- Skills endpoint returning error when called
- Unable to retrieve skills from database

## Solution

Changed method call from `list_available_skills()` to `list_skills()` in cipher router.

**File:** `backend/app/api/routers/cipher.py:58`

```python
# Before (incorrect):
return service.list_available_skills()

# After (correct):
return service.list_skills()
```

## Changes

- Fixed method name in `cipher.py` GET /skills endpoint
- Now correctly calls `CipherService.list_skills()` which queries database

## Testing

After applying this fix:
1. GET /cipher/skills endpoint works correctly
2. Returns list of enabled skills from database (empty until skills are registered)
3. Database query executes successfully via `db.list_skills(enabled_only=True)`

## Related

- Works with PR #40 (database backend fix)
- Completes skills endpoint functionality
- Skills table schema defined in `database.py:433` (SkillRegistry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to the skills retrieval service with no impact on user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->