### PR TITLE
feat(geometry): Phase 3 - Dynamic Zeta spectrum and Manifold3D surfaces

### DIFF
--- a/frontend/components/geometry/HyperbolicNavigator.tsx
+++ b/frontend/components/geometry/HyperbolicNavigator.tsx
@@ -36,6 +36,13 @@ interface CGPSuperNode {
   constellations: CGPConstellation[];
 }
 
+export interface ManifoldParams {
+  curvature_k?: number;
+  epsilon?: number;
+  surfaceFn?: string;
+  t?: number;
+}
+
 export interface HyperbolicNavigatorProps {
   data: {
     super_nodes: CGPSuperNode[];
@@ -43,6 +50,7 @@ export interface HyperbolicNavigatorProps {
   className?: string;
   width?: number;
   height?: number;
+  initialManifoldParams?: ManifoldParams | null;
 }
 
 
@@ -57,19 +65,26 @@ const Manifold3D = dynamic(() => import('./Manifold3D'), {
 
 
 // --- Main Navigator Component ---
-export function HyperbolicNavigator({ data, className, width = 800, height = 600 }: HyperbolicNavigatorProps) {
+export function HyperbolicNavigator({ data, className, width = 800, height = 600, initialManifoldParams }: HyperbolicNavigatorProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
   const { connection } = useNats();
   const [vizData, setVizData] = useState(data);
-  const [manifoldParams, setManifoldParams] = useState<any>(null);
+  const [manifoldParams, setManifoldParams] = useState<ManifoldParams | null>(initialManifoldParams || null);
   const [viewMode, setViewMode] = useState<'navigator' | 'manifold'>('navigator');
 
   // Sync prop data
   useEffect(() => {
     setVizData(data);
   }, [data]);
+
+  // Sync initial manifold params
+  useEffect(() => {
+    if (initialManifoldParams) {
+      setManifoldParams(initialManifoldParams);
+    }
+  }, [initialManifoldParams]);
 
   // NATS Subscription
   useEffect(() => {

--- a/frontend/components/geometry/Manifold3D.tsx
+++ b/frontend/components/geometry/Manifold3D.tsx
@@ -1,16 +1,136 @@
 "use client";
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useMemo, useCallback } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
-export default function Manifold3D({ width, height, params }: { width: number, height: number, params: any }) {
+interface ManifoldParams {
+    curvature_k?: number;
+    epsilon?: number;
+    surfaceFn?: string;
+    t?: number;
+}
+
+interface Props {
+    width: number;
+    height: number;
+    params: ManifoldParams | null;
+}
+
+/**
+ * Generate parametric surface geometry based on curvature type.
+ * Supports Hyperbolic (K < 0), Spherical (K > 0), and Flat (K ≈ 0) manifolds.
+ */
+function generateManifoldGeometry(
+    curvature_k: number,
+    epsilon: number,
+    segments: number = 50
+): THREE.BufferGeometry {
+    const positions: number[] = [];
+    const colors: number[] = [];
+    const indices: number[] = [];
+
+    const scale = Math.max(1, Math.abs(curvature_k)) * 2;
+
+    for (let i = 0; i <= segments; i++) {
+        const u = i / segments;
+        for (let j = 0; j <= segments; j++) {
+            const v = j / segments;
+
+            let x: number, y: number, z: number;
+            let r: number, g: number, b: number;
+
+            if (curvature_k < -0.1) {
+                // Hyperbolic (Pseudosphere/Tractrix-like)
+                const theta = u * 4 * Math.PI;
+                const phi = v * 2.9 + 0.1;
+                const k = Math.abs(curvature_k);
+
+                x = k * Math.cos(theta) * Math.sin(phi);
+                y = k * Math.sin(theta) * Math.sin(phi);
+                // Tractrix z-coordinate with logarithmic singularity clamped
+                const tanHalf = Math.tan(phi / 2);
+                const logVal = tanHalf > 0.001 ? Math.log(tanHalf) : -6;
+                z = -k * (Math.cos(phi) + Math.max(-6, Math.min(6, logVal)));
+
+                // Add epsilon noise
+                const noise = Math.sin(theta * 10) * epsilon * 0.1;
+                z += noise;
+
+                // Color: purple-cyan gradient
+                r = 0.5 + 0.5 * Math.sin(phi);
+                g = 0.2;
+                b = 1.0 - epsilon * 0.5;
+            } else if (curvature_k > 0.1) {
+                // Spherical
+                const theta = u * 2 * Math.PI;
+                const phi = v * Math.PI;
+                const k = Math.abs(curvature_k);
+
+                x = k * Math.sin(phi) * Math.cos(theta);
+                y = k * Math.sin(phi) * Math.sin(theta);
+                z = k * Math.cos(phi);
+
+                // Add epsilon wobble
+                const noise = Math.cos(phi * 20) * epsilon * 0.1;
+                x += noise;
+                y += noise;
+
+                // Color: orange-gold gradient
+                r = 1.0 - epsilon * 0.3;
+                g = 0.5 + 0.5 * Math.cos(theta);
+                b = 0.2;
+            } else {
+                // Flat (Euclidean plane with optional waves)
+                x = (u - 0.5) * scale * 5;
+                y = (v - 0.5) * scale * 5;
+                z = Math.sin(u * Math.PI * 2) * Math.cos(v * Math.PI * 2) * epsilon * 2;
+
+                // Color: gray-blue
+                r = 0.4;
+                g = 0.5 + z * 0.1;
+                b = 0.6;
+            }
+
+            positions.push(x, y, z);
+            colors.push(r, g, b);
+        }
+    }
+
+    // Generate triangle indices
+    for (let i = 0; i < segments; i++) {
+        for (let j = 0; j < segments; j++) {
+            const a = i * (segments + 1) + j;
+            const b = a + 1;
+            const c = a + (segments + 1);
+            const d = c + 1;
+
+            indices.push(a, b, c);
+            indices.push(b, d, c);
+        }
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+    geometry.setIndex(indices);
+    geometry.computeVertexNormals();
+
+    return geometry;
+}
+
+export default function Manifold3D({ width, height, params }: Props) {
     const mountRef = useRef<HTMLDivElement>(null);
     const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
     const sceneRef = useRef<THREE.Scene | null>(null);
     const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
     const meshRef = useRef<THREE.Mesh | null>(null);
+    const controlsRef = useRef<OrbitControls | null>(null);
     const reqRef = useRef<number>(0);
+
+    // Extract params with defaults
+    const curvature_k = params?.curvature_k ?? 0;
+    const epsilon = params?.epsilon ?? 0.1;
 
     // Initialize Three.js
     useEffect(() => {
@@ -38,6 +158,7 @@ export default function Manifold3D({ width, height, params }: { width: number, h
         controls.enableDamping = true;
         controls.autoRotate = true;
         controls.autoRotateSpeed = 1.0;
+        controlsRef.current = controls;
 
         // Lights
         const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
@@ -46,12 +167,13 @@ export default function Manifold3D({ width, height, params }: { width: number, h
         dirLight.position.set(10, 20, 10);
         scene.add(dirLight);
 
-        // Geometry (Initial)
-        const geometry = new THREE.PlaneGeometry(10, 10, 50, 50); // Placeholder
-        const material = new THREE.MeshPhongMaterial({ 
-            color: 0x60a5fa, // blue-400
-            wireframe: true,
-            side: THREE.DoubleSide
+        // Geometry - Generate based on curvature
+        const geometry = generateManifoldGeometry(curvature_k, epsilon);
+        const material = new THREE.MeshPhongMaterial({
+            vertexColors: true,
+            wireframe: false,
+            side: THREE.DoubleSide,
+            shininess: 80,
         });
         const mesh = new THREE.Mesh(geometry, material);
         meshRef.current = mesh;
@@ -61,12 +183,6 @@ export default function Manifold3D({ width, height, params }: { width: number, h
         const animate = () => {
             reqRef.current = requestAnimationFrame(animate);
             controls.update();
-
-            // Dynamic Update if SurfaceFn is present (Simplistic version)
-            if (meshRef.current && params?.t) {
-                 meshRef.current.rotation.z += 0.002; 
-            }
-
             renderer.render(scene, camera);
         };
         animate();
@@ -81,6 +197,20 @@ export default function Manifold3D({ width, height, params }: { width: number, h
             }
         };
     }, []);
+
+    // Update geometry when params change
+    useEffect(() => {
+        if (!meshRef.current || !sceneRef.current) return;
+
+        // Generate new geometry
+        const newGeometry = generateManifoldGeometry(curvature_k, epsilon);
+
+        // Dispose old geometry
+        meshRef.current.geometry.dispose();
+
+        // Apply new geometry
+        meshRef.current.geometry = newGeometry;
+    }, [curvature_k, epsilon]);
 
     // Handle Resize
     useEffect(() => {


### PR DESCRIPTION
## Summary

- Implement `compute_zeta_spectrum()` in GeometryEngine - derives frequencies from embedding covariance eigenvalues mapped to Riemann Zeta zeros
- Add dynamic surface generation in Manifold3D.tsx with three geometry types:
  - **Hyperbolic (K < -0.1)**: Tractrix/Pseudosphere surface
  - **Spherical (K > 0.1)**: Standard sphere parametrization
  - **Flat (K ≈ 0)**: Euclidean plane with epsilon waves
- Update geometry page to fetch manifold params from `/visualize_manifold` API
- Improve demo embedding generation for proper hyperbolic shape detection

## Test plan

- [x] Backend tests pass (6 new zeta spectrum tests)
- [x] Frontend renders hyperbolic surface for tree-like data
- [x] 2D/3D toggle works correctly
- [x] API returns correct curvature_k values

## Screenshots

3D Manifold view showing hyperbolic (Pseudosphere) surface for tree-like demo data.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Dynamic zeta spectrum computation now powers manifold visualizations instead of static values
* Hyperbolic manifold displays more varied, natural-looking embedding distributions
* Manifold geometry now adapts based on curvature parameters (hyperbolic, spherical, or flat)
* Enhanced visualization metadata includes computed spectrum details and embedding information

**Tests**
* Added comprehensive test coverage for spectrum computation across embedding scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->