### PR TITLE
feat(geometry): Phase 4 - NATS integration and shared context

### DIFF
--- a/backend/app/api/routers/cipher.py
+++ b/backend/app/api/routers/cipher.py
@@ -252,7 +252,15 @@ async def visualize_manifold(document_id: str = Body(..., embed=True)):
     # 5. Compute zeta spectrum from embeddings
     frequencies, amplitudes = geometry_engine.compute_zeta_spectrum(embeddings)
 
-    # 6. Return Link and metrics
+    # 6. Publish manifold update to NATS for real-time visualization
+    try:
+        import asyncio
+        asyncio.create_task(chit_service.publish_manifold_update(analysis))
+    except Exception as e:
+        # Non-blocking - log but don't fail the request
+        pass
+
+    # 7. Return Link and metrics
     return {
         "status": "ok",
         "shape": config.get("meta", {}).get("inferred_shape"),

--- a/frontend/lib/geometry-context.tsx
+++ b/frontend/lib/geometry-context.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+
+/**
+ * Shared state for synchronizing 2D (HyperbolicNavigator) and 3D (Manifold3D) views.
+ */
+interface GeometryContextType {
+    // Selection state
+    selectedNode: string | null;
+    selectedConstellation: string | null;
+    selectedPoint: string | null;
+
+    // View mode
+    viewMode: 'navigator' | 'manifold';
+
+    // Manifold parameters (shared between views)
+    manifoldParams: {
+        curvature_k: number;
+        epsilon: number;
+    };
+
+    // Actions
+    setSelectedNode: (id: string | null) => void;
+    setSelectedConstellation: (id: string | null) => void;
+    setSelectedPoint: (id: string | null) => void;
+    setViewMode: (mode: 'navigator' | 'manifold') => void;
+    setManifoldParams: (params: { curvature_k?: number; epsilon?: number }) => void;
+    clearSelection: () => void;
+}
+
+const GeometryContext = createContext<GeometryContextType | null>(null);
+
+interface GeometryProviderProps {
+    children: ReactNode;
+    initialParams?: {
+        curvature_k?: number;
+        epsilon?: number;
+    };
+}
+
+export function GeometryProvider({ children, initialParams }: GeometryProviderProps) {
+    const [selectedNode, setSelectedNode] = useState<string | null>(null);
+    const [selectedConstellation, setSelectedConstellation] = useState<string | null>(null);
+    const [selectedPoint, setSelectedPoint] = useState<string | null>(null);
+    const [viewMode, setViewMode] = useState<'navigator' | 'manifold'>('navigator');
+    const [manifoldParams, setManifoldParamsState] = useState({
+        curvature_k: initialParams?.curvature_k ?? 0,
+        epsilon: initialParams?.epsilon ?? 0.1,
+    });
+
+    const setManifoldParams = useCallback((params: { curvature_k?: number; epsilon?: number }) => {
+        setManifoldParamsState(prev => ({
+            ...prev,
+            ...params,
+        }));
+    }, []);
+
+    const clearSelection = useCallback(() => {
+        setSelectedNode(null);
+        setSelectedConstellation(null);
+        setSelectedPoint(null);
+    }, []);
+
+    const value: GeometryContextType = {
+        selectedNode,
+        selectedConstellation,
+        selectedPoint,
+        viewMode,
+        manifoldParams,
+        setSelectedNode,
+        setSelectedConstellation,
+        setSelectedPoint,
+        setViewMode,
+        setManifoldParams,
+        clearSelection,
+    };
+
+    return (
+        <GeometryContext.Provider value={value}>
+            {children}
+        </GeometryContext.Provider>
+    );
+}
+
+export function useGeometry(): GeometryContextType {
+    const context = useContext(GeometryContext);
+    if (!context) {
+        throw new Error('useGeometry must be used within a GeometryProvider');
+    }
+    return context;
+}
+
+/**
+ * Hook for optional geometry context (returns null if not in provider).
+ * Useful for components that can work with or without the context.
+ */
+export function useGeometryOptional(): GeometryContextType | null {
+    return useContext(GeometryContext);
+}


### PR DESCRIPTION
## Summary
- Add NATS subscription to Manifold3D for real-time manifold parameter updates
- Implement CGP publisher methods in ChitService (`publish_cgp`, `publish_manifold_update`, `create_cgp_from_document`)
- Create GeometryProvider context for 2D/3D view synchronization
- Add shape badge to geometry page header showing detected manifold type (Hyperbolic/Spherical/Flat)
- Backend publishes manifold updates to NATS after geometry analysis

## Test plan
- [ ] Verify Manifold3D receives NATS updates when backend publishes geometry events
- [ ] Confirm GeometryProvider shared state syncs between HyperbolicNavigator and Manifold3D
- [ ] Test shape badge displays correct manifold type with color coding
- [ ] Run existing test suite (`pytest tests/test_geometry*.py -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time manifold geometry updates now published asynchronously to the frontend.
  * Manifold metadata (shape, curvature parameters) displayed in the header.
  * Synchronized geometry state between 2D and 3D visualization views.
  * Geometry context management for unified selection and view mode handling across visualizations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->