### PR TITLE
feat(backend): add Ollama fallback for QA and search threshold filtering

### DIFF
--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -376,12 +376,13 @@ class SearchIndex:
         except Exception as exc:  # pragma: no cover - remote sync should not break local search
             LOGGER.warning("Failed to sync search embeddings to remote store: %s", exc)
 
-    def search(self, query: str, k: int = 10) -> List[SearchResult]:
+    def search(self, query: str, k: int = 10, threshold: float = 0.0) -> List[SearchResult]:
         """Search for similar chunks using vector similarity.
 
         Args:
             query: Search query text.
             k: Maximum number of results to return.
+            threshold: Minimum similarity score to include in results (default: 0.0).
 
         Returns:
             List of SearchResult objects sorted by similarity score.
@@ -409,6 +410,8 @@ class SearchIndex:
         out: List[SearchResult] = []
         for score, idx in zip(scores.tolist(), idxs.tolist()):
             if idx < 0 or idx >= len(self.payloads):
+                continue
+            if score < threshold:
                 continue
             ch = self.payloads[idx]
             out.append(SearchResult(score=float(score), text=ch["text"], meta=ch["meta"]))


### PR DESCRIPTION
## Summary
- Add `_try_ollama()` method to QAEngine for naive RAG when no structured metrics match the query
- Add `threshold` parameter to `SearchIndex.search()` to filter low-confidence results

## Details

### Ollama Fallback
When the QA engine doesn't find structured metric matches (spend, revenue, etc.), it now falls back to Ollama for a general RAG-style answer using document facts as context.

**Env vars:**
- `OLLAMA_BASE_URL` (default: `http://localhost:11434`)
- `OLLAMA_MODEL` (default: `llama3.1`)

### Search Threshold
The `search()` method now accepts an optional `threshold` parameter (default `0.0`) to skip results below a minimum similarity score.

## Test plan
- [ ] Verify QA still returns structured answers for known metrics
- [ ] Test Ollama fallback with a non-metric question (requires Ollama running)
- [ ] Test search with `threshold=0.5` filters low-confidence results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results can be filtered by a configurable quality score threshold; entries scoring below the threshold are excluded for more relevant results.
  * QA engine now provides AI-generated fallback answers when structured metric data is absent, returning a helpful response (with no evidence) instead of a “no data” result.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->