### PR TITLE
fix(frontend): NATS error handling and Dockerfile fix

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM node:20-alpine AS deps
 WORKDIR /app
-COPY package.json ./
+COPY package.json package-lock.json* ./
 COPY tsconfig.json ./
 COPY next.config.js ./
 COPY tailwind.config.js ./


### PR DESCRIPTION
## Summary
- Add try/catch wrapper for NATS subscription iterator in geometry components
- Handle `CONNECTION_CLOSED` errors gracefully with auto-reconnect message
- Fix Dockerfile `package-lock.json*` copy pattern for optional lockfile

## Changes
- `frontend/Dockerfile`: Fix COPY pattern for package-lock.json
- `frontend/components/geometry/HyperbolicNavigator.tsx`: NATS error handling
- `frontend/components/geometry/Manifold3D.tsx`: NATS error handling

## Test plan
- [ ] Verify geometry page loads without NATS errors
- [ ] Verify components reconnect automatically when NATS reconnects
- [ ] Verify Docker build succeeds with optional package-lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional 3D manifold visualization with configurable parameters and a 2D/3D view toggle.

* **Bug Fixes**
  * Improved subscription error handling and connection resilience; safer cleanup on component unmount.

* **Documentation**
  * Expanded inline documentation for manifold parameters and navigator props.

* **Chores**
  * Adjusted build inputs so package metadata is included during dependency install.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->