### PR TITLE
fix(docker): Remove hardcoded credential defaults and fix healthchecks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,18 +4,15 @@
 reviews:
   # Enable reviews
   review_status: true
-
-  # Branches to review
-  branches:
-    - "PMOVES.AI-Edition-Hardened"
-    - "feat/*"
-    - "fix/*"
-    - "docs/*"
-    - "chore/*"
-
-  # Disable reviews on these branches
-  excluded_branches:
-    - "main"
+  auto_review:
+    enabled: true
+    # Additional base branches to review (default branch is always included)
+    base_branches:
+      - "PMOVES.AI-Edition-Hardened"
+      - "feat/.*"
+      - "fix/.*"
+      - "docs/.*"
+      - "chore/.*"
 
 # Language setting
 language: "en-US"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,9 @@ services:
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@supabase-db:5432/postgres
       - SUPABASE_URL=${SUPABASE_URL:-http://supabase-proxy:3000}
       # Map parent env variable names to DoX expected names
+      # Support both SUPABASE_SERVICE_KEY (our standard) and SUPABASE_SERVICE_ROLE_KEY (Supabase CLI)
       - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
-      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
+      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY:-${SUPABASE_SERVICE_ROLE_KEY}}
       - REDIS_URL=redis://redis:6379
       - DB_BACKEND=${DB_BACKEND:-supabase}
       - NATS_URL=${NATS_URL:-nats://nats:4222}
@@ -120,6 +121,9 @@ services:
       - api_tier
     restart: unless-stopped
     healthcheck:
+      # NOTE: NATS scratch image has no shell tools. --help verifies binary exists
+      # but doesn't confirm the server is listening. Enable http_port: 8222 for
+      # monitoring endpoint if a more robust healthcheck is required.
       test: ["CMD", "nats-server", "--help"]
       interval: 30s
       timeout: 5s
@@ -356,7 +360,7 @@ services:
       - api_tier
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-s", "http://localhost:8000/mcp"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8000/mcp"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

- Remove all hardcoded credential defaults from docker-compose.yml
- Fix container healthchecks for minimal images (NATS, TensorZero, Cipher)
- Add CodeRabbit configuration for automated PR reviews

## Security Improvements

All hardcoded defaults removed - credentials now loaded exclusively from `.env.local`:

| Variable | Previous Default | Now |
|----------|------------------|-----|
| `POSTGRES_PASSWORD` | `postgres` | Required from env |
| `SUPABASE_ANON_KEY` | `local-dev-anon-key...` | Required from env |
| `SUPABASE_JWT_SECRET` | `super-secret-jwt...` | Required from env |
| `NEO4J_PASSWORD` | `pmovesNeo4jLocal2025` | Required from env |
| `CLICKHOUSE_USER/PASSWORD` | `tensorzero` | Required from env |
| `OPENAI_API_KEY` | `tensorzero` | Required from env |
| `AGENT_ZERO_MCP_TOKEN` | `pmoves-dox-mcp-token` | Required from env |

## Healthcheck Fixes

| Service | Issue | Fix |
|---------|-------|-----|
| NATS | Scratch image, no wget/curl | Use `nats-server --help` |
| Neo4j | Auth mismatch in cypher-shell | Use HTTP endpoint |
| TensorZero | No curl in image | Use wget |
| Cipher (DoX) | localhost DNS issue | Use 127.0.0.1 |
| Cipher (BoTZ) | Wrong endpoint | Use /mcp endpoint |
| Backend | curl not available | Use wget |

## Test Plan

- [x] All containers start with proper `.env.local`
- [x] All healthchecks pass (16/16 healthy)
- [x] TensorZero inference working
- [x] Search functionality working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration for continuous review.
  * Hardened deployment configuration: tightened secret and credential handling (removed unsafe defaults), consolidated key passthroughs, and clarified service environment requirements.
  * Improved service health monitoring: refined health checks, intervals, and startup probes for more reliable readiness signaling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->