### PR TITLE
docs: Add ReasoningService class docstring for storage lifecycle

### DIFF
--- a/backend/app/services/reasoning_service.py
+++ b/backend/app/services/reasoning_service.py
@@ -121,9 +121,21 @@ class ReasoningService:
     - Query and retrieve traces
     - Manage evidence pools for cross-step reference
 
+    Storage Lifecycle:
+        **IMPORTANT**: This service uses in-memory storage only. All reasoning
+        traces and evidence pools are stored in Python dictionaries and are
+        ephemeral. Data is NOT persisted across service restarts.
+
+        When the service is restarted (application restart, container restart,
+        or server reboot), all traces and evidence will be lost.
+
+        For persistent storage of reasoning traces, integrate with CipherService
+        which provides encrypted storage capabilities. See the cipher_service
+        module for details on persisting sensitive reasoning data.
+
     Attributes:
-        _traces: Dictionary of active reasoning traces by ID.
-        _evidence_pool: Dictionary of evidence pools by trace ID.
+        _traces: Dictionary of active reasoning traces by ID (in-memory only).
+        _evidence_pool: Dictionary of evidence pools by trace ID (in-memory only).
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- Adds comprehensive class-level docstring to `ReasoningService` documenting storage lifecycle
- Explicitly documents that storage is in-memory only (ephemeral)
- Notes that traces are NOT persisted across service restarts
- Provides guidance to integrate with `CipherService` for persistent storage
- Updates attribute docstrings to clarify in-memory nature

## Context
Follow-up from PR #80 review feedback. The module docstring already contained a note about ephemeral storage, but per coding guidelines the class docstring should also include this critical information for developers using the class directly.

## Test plan
- [x] Documentation only change - no functional impact
- [x] Verify docstring renders correctly in IDE tooltips
- [x] Verify docstring appears in generated API documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation clarifying that reasoning storage operates in-memory only and is not persisted across system restarts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->