### PR TITLE
chore: gitignore runtime CGP log artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ desktop.ini
 nul
 **/nul
 
+# Runtime CGP/CHIT artifacts
+pmoves/docs/logs/
+
 # Logs
 *.log
 npm-debug.log*


### PR DESCRIPTION
## Summary

- Adds `pmoves/docs/logs/` to `.gitignore` to exclude runtime CGP/CHIT artifacts
- The file `claude_review_latest.cgp.json` is session-specific, generated by CI review tools

## Test plan

- [ ] `git status` no longer shows `pmoves/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude runtime artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->