### PR TITLE
docs: fix TensorZero URL drift and drop hardcoded branch refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 PMOVES-DoX is a document intelligence platform for extracting, analyzing, and structuring data from PDFs, spreadsheets, XML logs, and API collections. It combines AI-powered processing (Docling, spaCy, LangExtract) with visualization tools (datavzrd) in a local-first architecture.
 
 **Main Branch**: `PMOVES.AI-Edition-Hardened` (for PRs)
-**Current Branch**: `feat/integrate-internal-agents`
 
 ## Documentation
 
@@ -269,7 +268,7 @@ Artifacts  Pages/       Chunks with         Structured   FAISS/NumPy
   - Tools available: `send_message`, `finish_chat`
 - **Configuration**:
   - Profile: `PROFILE=pmoves_custom` (uses `agents/pmoves_custom/` prompts)
-  - LLM orchestration: Uses TensorZero at `http://tensorzero:3000/v1`
+  - LLM orchestration: Uses TensorZero at `http://tensorzero-gateway:3000` (OpenAI-compatible routes under `/openai/v1`)
   - Models: `orchestrator` (chat), `utility` (util), `embed` (embeddings)
   - Settings file: `external/PMOVES-Agent-Zero/tmp/settings.json`
 - **Pattern similarity**: Follows same env-based switching as Supabase (database_factory.py) and Neo4j (PsyFeR knowledge graph)

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -7,7 +7,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 PMOVES-DoX is a document intelligence platform for extracting, analyzing, and structuring data from PDFs, spreadsheets, XML logs, and API collections. It combines AI-powered processing (Docling, spaCy, LangExtract) with visualization tools (datavzrd) in a local-first architecture.
 
 **Main Branch**: `PMOVES.AI-Edition-Hardened` (for PRs)
-**Current Branch**: `feat/integrate-internal-agents`
 
 ## Common Development Commands
 

--- a/docs/DOCKING_GUIDE.md
+++ b/docs/DOCKING_GUIDE.md
@@ -157,7 +157,7 @@ agent-zero:
     # Standalone Web UI
     - WEB_UI_PORT=50051
     # LLM orchestration
-    - TENSORZERO_API_BASE=http://tensorzero:3000/v1
+    - TENSORZERO_API_BASE=http://tensorzero-gateway:3000
   networks:
     - app_tier
     - api_tier

--- a/docs/agents/LEVEL3_AGENTS.md
+++ b/docs/agents/LEVEL3_AGENTS.md
@@ -522,7 +522,7 @@ async with KnowledgeManagerAgent("knowledge-001") as agent:
 
 ```yaml
 # TensorZero Integration
-TENSORZERO_BASE_URL: ${TENSORZERO_BASE_URL:-http://tensorzero:3000}
+TENSORZERO_BASE_URL: ${TENSORZERO_BASE_URL:-http://tensorzero-gateway:3000}
 
 # n8n Integration
 N8N_API_KEY: ${N8N_API_KEY}


### PR DESCRIPTION
## Summary
- Four docs used `http://tensorzero:3000/v1`; canonical container in this repo is `tensorzero-gateway:3000`. Aligns the stragglers with `docs/DEPLOYMENT.md`, `docs/demo/env.tier-*.example`, and `external/PMOVES-Agent-Zero/conf/model_providers.yaml`.
- `CLAUDE.md` and `docs/AGENT_GUIDE.md` hardcoded `feat/integrate-internal-agents` as the current branch. Removed — Main Branch line is sufficient and the current-branch ref rots fast.

## Files
- `CLAUDE.md`: drop branch line; fix TensorZero URL + add OpenAI-route path hint
- `docs/AGENT_GUIDE.md`: drop branch line
- `docs/DOCKING_GUIDE.md`: fix `TENSORZERO_API_BASE` env example
- `docs/agents/LEVEL3_AGENTS.md`: fix `TENSORZERO_BASE_URL` default

Doc-only — no runtime changes. `frontend/lib/api.ts` also references `tensorzero:3000` in a status fallback; intentionally left alone to keep this PR doc-scoped.

## Test plan
- [x] `git grep -n 'tensorzero:3000' -- '*.md'` returns only files inside `external/` (nested submodules, separate repos)
- [x] No env files or compose files touched (only narrative docs)

Surfaced by the PMOVES.AI CLAUDE.md fleet audit (2026-05-20). P0 item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)