### PR TITLE
fix(a2a): advertise A2UI v0.8 — the version we actually emit

### DIFF
--- a/backend/app/api/routers/a2a.py
+++ b/backend/app/api/routers/a2a.py
@@ -13,7 +13,7 @@ Endpoints:
     POST /a2a/geometry/analyze: Analyze semantic space geometry
     POST /a2a/task/execute: Execute a dispatched task
 
-Reference: https://a2ui.org/a2a-extension/a2ui/v0.9
+Reference: https://a2ui.org/a2a-extension/a2ui/v0.8
 """
 
 import json
@@ -270,12 +270,12 @@ def _build_default_capabilities() -> List[AgentCapability]:
     """Build default capability list for PMOVES-DoX."""
     return [
         AgentCapability(
-            uri="https://a2ui.org/a2a-extension/a2ui/v0.9",
+            uri="https://a2ui.org/a2a-extension/a2ui/v0.8",
             description="A2UI rendering capability for rich UI responses",
             required=False,
             params={
                 "supportedCatalogIds": [
-                    "https://a2ui.dev/specification/v0_9/standard_catalog.json"
+                    "https://github.com/google/A2UI/blob/main/specification/v0_8/json/standard_catalog_definition.json"
                 ],
                 "acceptsInlineCatalogs": True,
             },

--- a/backend/app/models/agent_card.py
+++ b/backend/app/models/agent_card.py
@@ -9,7 +9,7 @@ The AgentCard advertises:
 - MCP tools available for invocation
 - Input/output modalities supported
 
-Reference: https://a2ui.org/a2a-extension/a2ui/v0.9
+Reference: https://a2ui.org/a2a-extension/a2ui/v0.8
 """
 
 from pydantic import BaseModel, Field

--- a/backend/tests/test_a2ui_version_alignment.py
+++ b/backend/tests/test_a2ui_version_alignment.py
@@ -1,0 +1,130 @@
+"""The advertised A2UI extension version must match the dialect we actually emit.
+
+DoX advertises an A2UI A2A extension in its AgentCard and, separately, generates
+A2UI messages in A2UIService. Nothing structurally ties those two together, so
+they can drift: an A2A client that honours the advertisement would fetch the
+advertised catalog and then fail to parse what we send.
+
+The two dialects differ observably:
+
+    v0.8   {"surfaceUpdate": ...}    {"Text": {"text": {"literalString": ...},
+                                               "usageHint": ...}}
+    v0.9   {"updateComponents": ...} {"component": "Text", "text": ...,
+                                               "variant": ...}
+
+These tests derive the version from each side and assert they agree, rather than
+hard-coding one expected value -- so they keep working if DoX later moves to v0.9,
+and fail if only one side moves.
+
+The advertised side is read from the source with `ast` rather than by importing
+the router. Importing it pulls app.auth, which raises unless python-jose is
+installed, and a test that skips itself in that situation is a gate that cannot
+fail. Parsing the literal keeps this check running everywhere.
+"""
+import ast
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+import pytest
+
+from app.services.a2ui_service import A2UIService
+
+A2UI_EXTENSION_PREFIX = "https://a2ui.org/a2a-extension/a2ui/"
+A2A_ROUTER = BACKEND_DIR / "app" / "api" / "routers" / "a2a.py"
+
+
+def _literal_list(node) -> list:
+    if not isinstance(node, ast.List):
+        return []
+    return [el.value for el in node.elts if isinstance(el, ast.Constant)]
+
+
+def _advertised() -> tuple:
+    """(uri, supportedCatalogIds) for the A2UI capability, read from the source."""
+    assert A2A_ROUTER.is_file(), f"missing {A2A_ROUTER}"
+    tree = ast.parse(A2A_ROUTER.read_text(encoding="utf-8"))
+
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = getattr(func, "id", None) or getattr(func, "attr", None)
+        if name != "AgentCapability":
+            continue
+        kwargs = {kw.arg: kw.value for kw in node.keywords}
+        uri = kwargs.get("uri")
+        if not (isinstance(uri, ast.Constant) and A2UI_EXTENSION_PREFIX in str(uri.value)):
+            continue
+
+        catalog_ids = []
+        params = kwargs.get("params")
+        if isinstance(params, ast.Dict):
+            for key, value in zip(params.keys, params.values):
+                if isinstance(key, ast.Constant) and key.value == "supportedCatalogIds":
+                    catalog_ids = _literal_list(value)
+        found.append((uri.value, catalog_ids))
+
+    assert found, (
+        "no A2UI extension capability found in "
+        f"{A2A_ROUTER.relative_to(BACKEND_DIR)}; expected an AgentCapability whose uri "
+        f"begins with {A2UI_EXTENSION_PREFIX}"
+    )
+    assert len(found) == 1, f"expected exactly one A2UI capability, found {len(found)}"
+    return found[0]
+
+
+def _generated_dialect() -> str:
+    """Infer the A2UI version A2UIService actually emits, from its own output."""
+    surface = A2UIService.create_surface_update("surface-1", [])
+    begin = A2UIService.create_begin_rendering("surface-1", "root")
+    text = A2UIService.text("hello", usage_hint="h3")
+
+    if "surfaceUpdate" in surface and "beginRendering" in begin:
+        dialect = "v0.8"
+    elif "updateComponents" in surface:
+        dialect = "v0.9"
+    else:
+        pytest.fail(f"unrecognised message envelope: {sorted(surface)} / {sorted(begin)}")
+
+    # The component shape must agree with the envelope, or the generator is itself mixed.
+    nested_v08 = "Text" in text and "literalString" in str(text)
+    flat_v09 = text.get("component") == "Text"
+    if dialect == "v0.8":
+        assert nested_v08 and not flat_v09, (
+            f"envelope is v0.8 but the component shape is not the v0.8 nested form: {text}"
+        )
+    else:
+        assert flat_v09 and not nested_v08, (
+            f"envelope is v0.9 but the component shape is not the v0.9 flat form: {text}"
+        )
+    return dialect
+
+
+def test_advertised_extension_version_matches_generated_dialect():
+    uri, _ = _advertised()
+    advertised = uri[len(A2UI_EXTENSION_PREFIX):].strip("/")
+    generated = _generated_dialect()
+    assert advertised == generated, (
+        f"AgentCard advertises A2UI {advertised} but A2UIService emits {generated}. "
+        "A client honouring the advertisement would mis-parse our messages. "
+        "Move both, or neither."
+    )
+
+
+def test_supported_catalog_ids_reference_the_advertised_version():
+    uri, catalog_ids = _advertised()
+    advertised = uri[len(A2UI_EXTENSION_PREFIX):].strip("/")
+    # "v0.8" in the extension uri is spelled "v0_8" in specification paths.
+    expected_fragment = advertised.replace(".", "_")
+
+    assert catalog_ids, "A2UI capability advertises no supportedCatalogIds"
+    mismatched = [c for c in catalog_ids if expected_fragment not in c]
+    assert not mismatched, (
+        f"advertised extension is {advertised}, so catalog ids should reference "
+        f"{expected_fragment}; these do not: {mismatched}"
+    )


### PR DESCRIPTION
The AgentCard advertised the **v0.9** A2UI extension while `A2UIService` emits **v0.8**.

| | |
|---|---|
| Advertised (`a2a.py`) | `https://a2ui.org/a2a-extension/a2ui/v0.9` + a v0.9 catalog |
| Actually emitted (`a2ui_service.py`) | `surfaceUpdate` / `beginRendering`, `{"Text": {"text": {"literalString": ...}, "usageHint": ...}}` |

Under v0.9 those components are flat — `"component": "Text"` with a bare `text` and `variant`, and `ChoicePicker` rather than `MultipleChoice`. A client honouring the advertisement would fetch the v0.9 catalog and mis-parse everything we send.

## Direction: correct the advertisement, don't migrate

Everything in the wider PMOVES estate that moves A2UI bytes is already v0.8 — the NATS bridge, the static stage surface, the vendored Lit bundle, the A2UI editor. And `@a2ui/lit` implements **only** v0.8 (`renderers/lit/src` contains a single `0.8` directory), so moving up is blocked on upstream renderer support that doesn't exist yet.

Values come from the v0.8 spec itself, not guesswork: `specification/v0_8/docs/a2ui_extension_specification.md` gives the uri on line 9 and the catalog id in its own example block. Worth noting the canonical catalog id is the `google/A2UI` blob URL — so the previous `a2ui.dev/...standard_catalog.json` was non-canonical on **both** version and host.

## The test

`tests/test_a2ui_version_alignment.py` derives the version from each side and asserts they agree, rather than hard-coding one. It keeps working if DoX later moves to v0.9, and fails if only one side moves. It also catches a generator that's internally mixed (v0.8 envelope with v0.9 component shape).

It reads the advertised capability from source via `ast` instead of importing the router. Importing pulls `app.auth`, which raises without `python-jose` — the first draft of this test **silently skipped both cases** for that reason, i.e. a gate that could not fail. Parsing the literal keeps it running everywhere.

**Proven non-vacuous.** Against the unfixed code:

```
AssertionError: AgentCard advertises A2UI v0.9 but A2UIService emits v0.8.
1 failed, 1 passed
```

After the fix: `2 passed`.

## Not run

The wider backend suite. `tests/test_geometry_api.py` cannot be collected in this environment (`ModuleNotFoundError: dotenv`), which is pre-existing and unrelated.

---

Found during an A2UI integration audit of PMOVES.AI (POWERFULMOVES/PMOVES.AI#2561, finding F9). Once merged, the PMOVES.AI gitlink for `PMOVES-DoX` needs bumping to pick it up.